### PR TITLE
fix typo with error-handling

### DIFF
--- a/console/settings.py
+++ b/console/settings.py
@@ -50,7 +50,7 @@ env_file = os.path.join(BASE_DIR, '.env')
 # Attempt to load the Project ID into the environment, safely failing on error.
 try:
     _, os.environ['GOOGLE_CLOUD_PROJECT'] = google.auth.default()
-except google.exceptions.DefaultCredentialsError:
+except google.auth.exceptions.DefaultCredentialsError:
     pass
 
 # Use a local secret file, if provided.


### PR DESCRIPTION
really basic one but something I encountered. `AttributeError` instead of the exception we actually want to raise.